### PR TITLE
change url due to amplify redirect

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,12 +7,12 @@ export default {
   oidc: {
     clientId: CLIENT_ID,
     issuer: ISSUER,
-    redirectUri: "https://ping-catcher.com/implicit/callback",
+    redirectUri: "https://www.ping-catcher.com/implicit/callback",
     scopes: ["openid", "profile", "email"],
     pkce: true,
     disableHttpsCheck: OKTA_TESTING_DISABLEHTTPSCHECK,
   },
   resourceServer: {
-    messagesUrl: "https://ping-catcher.com/api/messages",
+    messagesUrl: "https://www.ping-catcher.com/api/messages",
   },
 };


### PR DESCRIPTION
# Description

Amplify redirects from FQDN to www.FQDN and may be losing okta token

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

- [x] Live

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
